### PR TITLE
fix build on archlinux 'multiple definition of..'

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -Wall -Wextra -O2 -mtune=native
+AM_CFLAGS = -Wall -Wextra -O2 -mtune=native -fcommon
 bin_PROGRAMS = cube
 SHARED_CFILES = mechanics.c rotations.c representation.c operations.c status.c patterns.c solver.c
 SHARED_HFILES = mechanics.h rotations.h representation.h operations.h status.h patterns.h solver.h


### PR DESCRIPTION
This is because in previous versions of gcc on archlinux the default of `-fcommon` was changed to `-fno-common`

To fix:
```
$ make
...
/sbin/ld: solver.o:/tmp/cube/src/patterns.h:4: multiple definition of `solved_cube'; cube.o:/tmp/cube/src/operations.h:4: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:340: cube] Error 1
```